### PR TITLE
Corrige uso de single para maybeSingle

### DIFF
--- a/src/contexts/PermissionsContext.tsx
+++ b/src/contexts/PermissionsContext.tsx
@@ -26,17 +26,18 @@ export const PermissionsProvider = ({ children }: { children: ReactNode }) => {
         .from('profiles')
         .select('role')
         .eq('user_id', userId)
-        .single();
+        .maybeSingle();
 
       if (profileError) {
-        // Se o perfil não for encontrado, trata como um membro padrão sem permissões
-        if (profileError.code === 'PGRST116') {
-            setProfileRole('member');
-            setIsAdmin(false);
-            setPermissions(new Set());
-            return;
-        }
         throw profileError;
+      }
+
+      if (!profile) {
+        // Se não existir perfil para este utilizador, assume papel 'member' sem permissões
+        setProfileRole('member');
+        setIsAdmin(false);
+        setPermissions(new Set());
+        return;
       }
 
       const userRole = profile?.role || 'member';


### PR DESCRIPTION
## Summary
- evita erro 406 ao buscar perfil do usuário

## Testing
- `npm run lint` *(falhou: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685198f45a6c832c93134dff409a2b39